### PR TITLE
Move container images to dockerhub and make other speed optimizations

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,1 @@
+trigger build

--- a/.ignore
+++ b/.ignore
@@ -1,1 +1,0 @@
-trigger build

--- a/docker-compose.yml.tmpl
+++ b/docker-compose.yml.tmpl
@@ -4,7 +4,7 @@ services:
     image: dwmkerr/dynamodb
     restart: always
   kube:
-    image: slateci/kube
+    image: slateci/ms-kube
     restart: always
     tty: true
     privileged: true
@@ -28,7 +28,7 @@ services:
     depends_on:
       - db
       - kube
-    image: slateci/slate
+    image: slateci/ms-slate
     command: /usr/bin/supervisord -c /etc/supervisord.conf
     stdin_open: true
     tty: true

--- a/docker-compose.yml.tmpl
+++ b/docker-compose.yml.tmpl
@@ -4,8 +4,7 @@ services:
     image: dwmkerr/dynamodb
     restart: always
   kube:
-    build:
-      context: kube/
+    image: slateci/kube
     restart: always
     tty: true
     privileged: true
@@ -29,8 +28,7 @@ services:
     depends_on:
       - db
       - kube
-    build:
-      context: slate/
+    image: slateci/slate
     command: /usr/bin/supervisord -c /etc/supervisord.conf
     stdin_open: true
     tty: true

--- a/kube/Dockerfile
+++ b/kube/Dockerfile
@@ -24,6 +24,7 @@ RUN echo 'deb http://apt.kubernetes.io/ kubernetes-xenial main' > /etc/apt/sourc
 RUN apt-get update && apt-get install -y docker-ce kubelet=1.14.0-00 kubeadm=1.14.0-00 kubectl=1.14.0-00 && apt-get clean
 RUN curl -s https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
 RUN helm init --client-only
+RUN kubeadm config images pull
 
 # Increase vm.max_map_count, originally for elasticsearch
 RUN echo "vm.max_map_count=262144" >> /etc/sysctl.conf

--- a/kube/Dockerfile
+++ b/kube/Dockerfile
@@ -24,7 +24,6 @@ RUN echo 'deb http://apt.kubernetes.io/ kubernetes-xenial main' > /etc/apt/sourc
 RUN apt-get update && apt-get install -y docker-ce kubelet=1.14.0-00 kubeadm=1.14.0-00 kubectl=1.14.0-00 && apt-get clean
 RUN curl -s https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
 RUN helm init --client-only
-RUN kubeadm config images pull
 
 # Increase vm.max_map_count, originally for elasticsearch
 RUN echo "vm.max_map_count=262144" >> /etc/sysctl.conf

--- a/kube/Dockerfile
+++ b/kube/Dockerfile
@@ -28,8 +28,6 @@ RUN helm init --client-only
 # Increase vm.max_map_count, originally for elasticsearch
 RUN echo "vm.max_map_count=262144" >> /etc/sysctl.conf
 
-RUN systemctl enable --now docker
-
 RUN docker pull k8s.gcr.io/hyperkube:v1.14.0 && docker save -o hyperkube.tar k8s.gcr.io/hyperkube:v1.14.0
 COPY kube/config.yaml .
 COPY kube/init.sh .

--- a/kube/Dockerfile
+++ b/kube/Dockerfile
@@ -29,8 +29,8 @@ RUN helm init --client-only
 RUN echo "vm.max_map_count=262144" >> /etc/sysctl.conf
 
 RUN docker pull k8s.gcr.io/hyperkube:v1.14.0 && docker save -o hyperkube.tar k8s.gcr.io/hyperkube:v1.14.0
-COPY config.yaml .
-COPY init.sh .
+COPY kube/config.yaml .
+COPY kube/init.sh .
 RUN chmod +x init.sh
 EXPOSE 30000-30100
 CMD ["/bin/bash", "-c", "exec /sbin/init --log-target=journal 3>&1"]

--- a/kube/Dockerfile
+++ b/kube/Dockerfile
@@ -28,7 +28,6 @@ RUN helm init --client-only
 # Increase vm.max_map_count, originally for elasticsearch
 RUN echo "vm.max_map_count=262144" >> /etc/sysctl.conf
 
-RUN docker pull k8s.gcr.io/hyperkube:v1.14.0 && docker save -o hyperkube.tar k8s.gcr.io/hyperkube:v1.14.0
 COPY kube/config.yaml .
 COPY kube/init.sh .
 RUN chmod +x init.sh

--- a/kube/Dockerfile
+++ b/kube/Dockerfile
@@ -28,7 +28,7 @@ RUN helm init --client-only
 # Increase vm.max_map_count, originally for elasticsearch
 RUN echo "vm.max_map_count=262144" >> /etc/sysctl.conf
 
-COPY hyperkube.tar .
+RUN docker pull k8s.gcr.io/hyperkube:v1.14.0 && docker save -o hyperkube.tar k8s.gcr.io/hyperkube:v1.14.0
 COPY config.yaml .
 COPY init.sh .
 RUN chmod +x init.sh

--- a/kube/Dockerfile
+++ b/kube/Dockerfile
@@ -28,6 +28,8 @@ RUN helm init --client-only
 # Increase vm.max_map_count, originally for elasticsearch
 RUN echo "vm.max_map_count=262144" >> /etc/sysctl.conf
 
+RUN systemctl enable --now docker
+
 RUN docker pull k8s.gcr.io/hyperkube:v1.14.0 && docker save -o hyperkube.tar k8s.gcr.io/hyperkube:v1.14.0
 COPY kube/config.yaml .
 COPY kube/init.sh .

--- a/kube/init.sh
+++ b/kube/init.sh
@@ -6,6 +6,7 @@ echo "FallbackDNS=8.8.4.4" >> /etc/systemd/resolved.conf
 systemctl restart systemd-resolved
 systemctl restart kubelet
 # Import cached hyperkube image
+docker pull k8s.gcr.io/hyperkube:v1.14.0 && docker save -o hyperkube.tar k8s.gcr.io/hyperkube:v1.14.0
 docker load -i /hyperkube.tar
 rm -f /hyperkube.tar
 # Install Kubernetes

--- a/kube/init.sh
+++ b/kube/init.sh
@@ -4,12 +4,29 @@ set -e
 echo "DNS=8.8.8.8" >> /etc/systemd/resolved.conf
 echo "FallbackDNS=8.8.4.4" >> /etc/systemd/resolved.conf
 systemctl restart systemd-resolved
-systemctl restart kubelet
+
 # Import cached hyperkube image
-docker pull k8s.gcr.io/hyperkube:v1.14.0 && docker save -o hyperkube.tar k8s.gcr.io/hyperkube:v1.14.0
-docker load -i /hyperkube.tar
-rm -f /hyperkube.tar
-# Install Kubernetes
+# docker pull k8s.gcr.io/hyperkube:v1.14.0 && docker save -o hyperkube.tar k8s.gcr.io/hyperkube:v1.14.0
+# docker load -i /hyperkube.tar
+# rm -f /hyperkube.tar
+
+# Try grabbing packages manually instead of hyperkube
+cat <<EOF > /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+exclude=kube*
+EOF
+
+yum install -y kubelet kubeadm kubectl --disableexcludes=kubernetes
+
+systemctl enable --now kubelet
+
+# Deploy Kubernetes
 kubeadm init --config config.yaml --ignore-preflight-errors=all
 # Remove master taint
 kubectl taint nodes --all node-role.kubernetes.io/master-

--- a/kube/init.sh
+++ b/kube/init.sh
@@ -4,16 +4,7 @@ set -e
 echo "DNS=8.8.8.8" >> /etc/systemd/resolved.conf
 echo "FallbackDNS=8.8.4.4" >> /etc/systemd/resolved.conf
 systemctl restart systemd-resolved
-
-# Import cached hyperkube image
-# docker pull k8s.gcr.io/hyperkube:v1.14.0 && docker save -o hyperkube.tar k8s.gcr.io/hyperkube:v1.14.0
-# docker load -i /hyperkube.tar
-# rm -f /hyperkube.tar
-
-# Try grabbing packages manually instead of hyperkube
-
 systemctl enable --now kubelet
-
 # Deploy Kubernetes
 kubeadm init --config config.yaml --ignore-preflight-errors=all
 # Remove master taint

--- a/kube/init.sh
+++ b/kube/init.sh
@@ -11,18 +11,6 @@ systemctl restart systemd-resolved
 # rm -f /hyperkube.tar
 
 # Try grabbing packages manually instead of hyperkube
-cat <<EOF > /etc/yum.repos.d/kubernetes.repo
-[kubernetes]
-name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
-enabled=1
-gpgcheck=1
-repo_gpgcheck=1
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-exclude=kube*
-EOF
-
-yum install -y kubelet kubeadm kubectl --disableexcludes=kubernetes
 
 systemctl enable --now kubelet
 

--- a/minislate
+++ b/minislate
@@ -154,8 +154,13 @@ elif args.c1 == 'destroy':
             pass
 elif args.c1 == 'build':
   args.c2 = args.c2 or ''
-  if args.c2 == 'kube' or args.c2 == '':
-    run('docker-compose -f docker-compose.yml.tmpl build --no-cache ' + args.c2)
+  print('WARNING Building locally can take more than 15 minutes')
+  print('It is reccomended to use hosted images by running ./minislate init')
+  print('Building the kube container...')
+  run('docker build . --file=kube/Dockerfile --tag=slateci/ms-kube')
+  print('Building the slate container...')
+  run('docker build . --file=slate/Dockerfile --tag=slateci/ms-slate')
+  print('MiniSLATE build complete run `./minislate init` to initialize locally built images')
 elif args.c1 == 'shell':
   initcheck()
   readycheck()

--- a/minislate
+++ b/minislate
@@ -115,10 +115,6 @@ if args.c1 == 'init':
     except:
       raise EnvironmentError('Could not run docker-compose. Is it installed?')
     if(run('docker-compose up -d') == 0):
-      try:
-        os.remove('kube/hyperkube.tar')
-      except OSError:
-        pass
       if(run('docker-compose exec kube ./init.sh') == 0 and run('docker-compose exec slate ./init.sh') == 0):
         if volumes:
           print('\033[1m'+"Volume Mounts:"+'\033[0m'+'\n'+volumes)
@@ -160,10 +156,6 @@ elif args.c1 == 'build':
   args.c2 = args.c2 or ''
   if args.c2 == 'kube' or args.c2 == '':
     run('docker-compose -f docker-compose.yml.tmpl build --no-cache ' + args.c2)
-  try:
-      os.remove('kube/hyperkube.tar')
-  except OSError:
-      pass
 elif args.c1 == 'shell':
   initcheck()
   readycheck()

--- a/minislate
+++ b/minislate
@@ -161,6 +161,20 @@ elif args.c1 == 'build':
   print('Building the slate container...')
   run('docker build . --file=slate/Dockerfile --tag=slateci/ms-slate')
   print('MiniSLATE build complete run `./minislate init` to initialize locally built images')
+  if (args.c2 == 'kube'):
+    print('Building the kube container...')
+    run('docker build . --file=kube/Dockerfile --tag=slateci/ms-kube')
+    print('miniSLATE kube container built successfully')
+  elif (args.c2 == 'slate'):
+    print('Building the slate container...')
+    run('docker build . --file=slate/Dockerfile --tag=slateci/ms-slate')
+    print('miniSLATE slate container built successfully')
+  else: 
+    print('Building the kube container...')
+    run('docker build . --file=kube/Dockerfile --tag=slateci/ms-kube')
+    print('Building the slate container...')
+    run('docker build . --file=slate/Dockerfile --tag=slateci/ms-slate')
+    print('MiniSLATE build complete run `./minislate init` to initialize locally built images')
 elif args.c1 == 'shell':
   initcheck()
   readycheck()

--- a/minislate
+++ b/minislate
@@ -159,7 +159,7 @@ elif args.c1 == 'destroy':
 elif args.c1 == 'build':
   args.c2 = args.c2 or ''
   if args.c2 == 'kube' or args.c2 == '':
-  run('docker-compose -f docker-compose.yml.tmpl build --no-cache ' + args.c2)
+    run('docker-compose -f docker-compose.yml.tmpl build --no-cache ' + args.c2)
   try:
       os.remove('kube/hyperkube.tar')
   except OSError:

--- a/minislate
+++ b/minislate
@@ -90,9 +90,6 @@ if args.c1 == 'init':
     if os.path.isfile('docker-compose.yml'):
         raise EnvironmentError(
             'MiniSLATE is already initialized. Run `./minislate destroy && ./minislate init` to reset your environment.')
-    print("Caching Hyperkube image")
-    run('/bin/sh -c "docker pull k8s.gcr.io/hyperkube:' + KUBEVER + ' && \
-      docker save -o kube/hyperkube.tar k8s.gcr.io/hyperkube:' + KUBEVER + '"')
     ports = []
     volumes = []
     if args.ports:

--- a/minislate
+++ b/minislate
@@ -156,11 +156,6 @@ elif args.c1 == 'build':
   args.c2 = args.c2 or ''
   print('WARNING Building locally can take more than 15 minutes')
   print('It is reccomended to use hosted images by running ./minislate init')
-  print('Building the kube container...')
-  run('docker build . --file=kube/Dockerfile --tag=slateci/ms-kube')
-  print('Building the slate container...')
-  run('docker build . --file=slate/Dockerfile --tag=slateci/ms-slate')
-  print('MiniSLATE build complete run `./minislate init` to initialize locally built images')
   if (args.c2 == 'kube'):
     print('Building the kube container...')
     run('docker build . --file=kube/Dockerfile --tag=slateci/ms-kube')

--- a/minislate
+++ b/minislate
@@ -159,9 +159,6 @@ elif args.c1 == 'destroy':
 elif args.c1 == 'build':
   args.c2 = args.c2 or ''
   if args.c2 == 'kube' or args.c2 == '':
-      print("Caching Hyperkube image")
-      run('/bin/sh -c "docker pull k8s.gcr.io/hyperkube:' + KUBEVER + ' && \
-      docker save -o kube/hyperkube.tar k8s.gcr.io/hyperkube:' + KUBEVER + '"')
   run('docker-compose -f docker-compose.yml.tmpl build --no-cache ' + args.c2)
   try:
       os.remove('kube/hyperkube.tar')

--- a/slate/Dockerfile
+++ b/slate/Dockerfile
@@ -4,9 +4,9 @@ ENV KUBECONFIG=/etc/kubernetes/admin.conf
 
 WORKDIR /src
 
-COPY kubernetes.repo /etc/yum.repos.d/kubernetes.repo
-COPY aws-sdk.repo /etc/yum.repos.d/aws-sdk.repo
-COPY slate-server.repo /etc/yum.repos.d/slate-server.repo
+COPY slate/kubernetes.repo /etc/yum.repos.d/kubernetes.repo
+COPY slate/aws-sdk.repo /etc/yum.repos.d/aws-sdk.repo
+COPY slate/slate-server.repo /etc/yum.repos.d/slate-server.repo
 RUN yum install -y epel-release
 RUN yum install -y ca-certificates git vim which kubectl boost zlib openssl libcurl openssl gcc python-devel libffi-devel net-tools supervisor
 
@@ -37,8 +37,8 @@ RUN sh -c 'echo "http://localhost:18080" | tee /root/.slate/endpoint /opt/slate-
 RUN sh -c 'echo "5B121807-7D5D-407A-8E22-5F001EF594D4" | tee /root/.slate/token /etc/slate/secrets/slate_api_token.txt > /dev/null'
 RUN chmod -R 600 /root/.slate
 
-COPY slate_portal_user /
-COPY init.sh /
+COPY slate/slate_portal_user /
+COPY slate/init.sh /
 EXPOSE 5000 51000 18080
 RUN chmod +x init.sh
 

--- a/slate/Dockerfile
+++ b/slate/Dockerfile
@@ -42,4 +42,4 @@ COPY slate/init.sh /
 EXPOSE 5000 51000 18080
 RUN chmod +x init.sh
 
-COPY supervisord.conf /etc/supervisord.conf
+COPY slate/supervisord.conf /etc/supervisord.conf

--- a/slate/Dockerfile
+++ b/slate/Dockerfile
@@ -29,6 +29,7 @@ RUN git clone https://github.com/slateci/slate-portal.git .
 RUN bash -c 'virtualenv venv && source venv/bin/activate && pip install --no-cache-dir -r requirements.txt'
 RUN mkdir /opt/slate-portal/instance && cp /opt/slate-portal/portal/portal.conf /opt/slate-portal/instance/
 RUN sed -i -e 's/localhost/0\.0\.0\.0/g' -e 's/ssl_context=([^)]*)//' /opt/slate-portal/run_*
+RUN pip install -r /opt/slate-portal/requirements.txt
 
 WORKDIR /
 RUN dd if=/dev/urandom of=encryptionKey bs=1024 count=1

--- a/slate/init.sh
+++ b/slate/init.sh
@@ -5,7 +5,6 @@ normal=$(tput sgr0)
 helm init --service-account tiller
 kubectl rollout status -w deployment/tiller-deploy --namespace=kube-system
 helm install --namespace kube-system --set nfs.server=nfs --set nfs.path=/ --set storageClass.defaultClass=true stable/nfs-client-provisioner
-pip install -r /opt/slate-portal/requirements.txt
 slate group create my-group --field 'Resource Provider'
 slate cluster create my-cluster --group my-group --org SLATE --no-ingress -y
 printf "\n${bold}=============================================================\n${normal}"


### PR DESCRIPTION
This is in regards to https://github.com/slateci/minislate/issues/26

Move images for minislate-kube and minislate-slate containers to Dockerhub, so that users do not have to build images locally. This improves the speed at which minislate can be deployed. 