### PR TITLE
Add flag to minislate for use with Selenium testing infrastructure

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -23,6 +23,8 @@ __publish__ [-p, --publish, --port] - Publish a port in the Kubernetes container
 
 If a single port is specified (e.g. `-p 3000`) that port will be mapped to the same port on the host.
 
+__selenium__ [-s, --selenium] - For use with automated testing infastructure. Disables the `tty` option in the docker-compose bring up of Minislate.
+
 ### Status
 View status of minislate containers
 ```

--- a/README.md
+++ b/README.md
@@ -59,4 +59,10 @@ Be sure this proccess doesn't get interrupted, or you may have to destroy again.
 
 `./minislate destroy --rmi && ./minislate init`
 
+## Test Infrastructure
+It may be nescasary to spin up Minislate in an automated way. For example, the Selenium portal tests automatically creates a Minislate cluster to test against. These clusters may require that `tty` is disabled inside the container. Minislate init can be run with the --selenium or -s flag to disable `tty` for automated testing.
+
+Example:
+
+`./minislate init -s`
 

--- a/minislate
+++ b/minislate
@@ -15,7 +15,7 @@ init.add_argument('-p', '--port', '--publish', dest='ports', action='append', na
                   metavar='hostPort or hostPort:containerPort', help='Example: `./minislate init -p 3000`')
 init.add_argument('-v', '--volume', dest='volumes', action='append', nargs='?',
                   metavar='hostDir or hostDir:containerDir', help='Example: `./minislate init -v ~/workdir`')
-init.add_argument('-s', '--selenium', dest='selenium', help='Runs minislate without TTY, for use with Selenium test infrastructure')
+init.add_argument('-s', '--selenium', dest='selenium', action='store_true', help='Runs minislate without TTY, for use with Selenium test infrastructure')
 subparsers.add_parser('pause', help='pause minislate containers')
 subparsers.add_parser('unpause', help='unpause minislate containers')
 destroy = subparsers.add_parser('destroy', help='completely destroy environment')

--- a/minislate
+++ b/minislate
@@ -15,6 +15,7 @@ init.add_argument('-p', '--port', '--publish', dest='ports', action='append', na
                   metavar='hostPort or hostPort:containerPort', help='Example: `./minislate init -p 3000`')
 init.add_argument('-v', '--volume', dest='volumes', action='append', nargs='?',
                   metavar='hostDir or hostDir:containerDir', help='Example: `./minislate init -v ~/workdir`')
+init.add_argument('-s', '--selenium', dest='selenium', action='append', help='Runs minislate without TTY, for use with Selenium test infrastructure')
 subparsers.add_parser('pause', help='pause minislate containers')
 subparsers.add_parser('unpause', help='unpause minislate containers')
 destroy = subparsers.add_parser('destroy', help='completely destroy environment')
@@ -104,6 +105,8 @@ if args.c1 == 'init':
         contents = file.read()
     contents = contents.replace('# {PORTS}', ports)
     contents = contents.replace('# {VOLUMES}', volumes)
+    if args.selenium:
+      contents = contents.replace('tty: true', 'tty: false')
     with open('docker-compose.yml', 'w') as file:
         file.write(contents)
         file.flush()

--- a/minislate
+++ b/minislate
@@ -15,7 +15,7 @@ init.add_argument('-p', '--port', '--publish', dest='ports', action='append', na
                   metavar='hostPort or hostPort:containerPort', help='Example: `./minislate init -p 3000`')
 init.add_argument('-v', '--volume', dest='volumes', action='append', nargs='?',
                   metavar='hostDir or hostDir:containerDir', help='Example: `./minislate init -v ~/workdir`')
-init.add_argument('-s', '--selenium', dest='selenium', action='append', help='Runs minislate without TTY, for use with Selenium test infrastructure')
+init.add_argument('-s', '--selenium', dest='selenium', help='Runs minislate without TTY, for use with Selenium test infrastructure')
 subparsers.add_parser('pause', help='pause minislate containers')
 subparsers.add_parser('unpause', help='unpause minislate containers')
 destroy = subparsers.add_parser('destroy', help='completely destroy environment')


### PR DESCRIPTION
Allow Minislate to be run in "headless" fashion. Adds the `--selenium` or `-s` flag to `./minislate init` which disables TTY inside the container.